### PR TITLE
Update type definition for getStoredState

### DIFF
--- a/type-definitions/index.d.ts
+++ b/type-definitions/index.d.ts
@@ -60,7 +60,7 @@ declare module "redux-persist" {
 
   export function createTransform<State, Raw>(transformIn: TransformIn<State, Raw>, transformOut: TransformOut<Raw, State>, config?: TransformConfig): Transform<State, Raw>;
 
-  export function getStoredState(persistorConfig?: PersistorConfig, onComplete?: OnComplete<any>): undefined;
+  export function getStoredState(persistorConfig?: PersistorConfig, onComplete?: OnComplete<any>): Promise<any>;
 
   export function persistStore<State>(store: Store<State>, persistorConfig?: PersistorConfig, onComplete?: OnComplete<any>): Persistor;
 


### PR DESCRIPTION
`getStoredState` return type changed to `Promise<any>`

 This helps avoid typescript error "Operand for 'await' does not have a valid callable 'then' member.." when using with await; e.g. `await getStoredState(persistConfig)`